### PR TITLE
add XML tag for Android Pay

### DIFF
--- a/lib/cybersource/ext/active_merchant/active_merchant.rb
+++ b/lib/cybersource/ext/active_merchant/active_merchant.rb
@@ -29,14 +29,13 @@ module ActiveMerchant
       def add_auth_service(xml, payment_method, options)
         if network_tokenization?(payment_method)
           add_network_tokenization(xml, payment_method, options)
+          add_payment_solution(xml, payment_method)
         else
           xml.tag! 'ccAuthService', {'run' => 'true'} do
             # Let CyberSource figure it out otherwise (internet is the default unless tokens are used)
             xml.tag!("commerceIndicator", options[:commerce_indicator]) unless options[:commerce_indicator].blank?
           end
         end
-        # Add support for Android Pay
-        xml.tag!("paymentSolution", @options[:payment_solution]) unless options[:payment_solution].blank?
       end
 
       # Changes:
@@ -71,6 +70,12 @@ module ActiveMerchant
         end
       end
 
+      # Changes:
+      #  * http://apps.cybersource.com/library/documentation/dev_guides/Android_Pay_SO_API/html/wwhelp/wwhimpl/js/html/wwhelp.htm#href=ch_soAPI.html
+      #  * add paymentSolution tag to support Android Pay
+      def add_payment_solution(xml, payment_method)
+        xml.tag!("paymentSolution", "006") if (!payment_method.source.nil? && payment_method.source == :android_pay)
+      end
       # Changes:
       #  * Enable business rules for Apple Pay
       #  * Set paymentNetworkToken if needed (a bit of a hack to do it here, but it avoids having to override too much code)

--- a/lib/cybersource/ext/active_merchant/active_merchant.rb
+++ b/lib/cybersource/ext/active_merchant/active_merchant.rb
@@ -74,7 +74,7 @@ module ActiveMerchant
       #  * http://apps.cybersource.com/library/documentation/dev_guides/Android_Pay_SO_API/html/wwhelp/wwhimpl/js/html/wwhelp.htm#href=ch_soAPI.html
       #  * add paymentSolution tag to support Android Pay
       def add_payment_solution(xml, payment_method)
-        xml.tag!("paymentSolution", "006") if (!payment_method.source.nil? && payment_method.source == :android_pay)
+        xml.tag!("paymentSolution", "006") if payment_method.source == :android_pay
       end
       # Changes:
       #  * Enable business rules for Apple Pay

--- a/lib/cybersource/ext/active_merchant/active_merchant.rb
+++ b/lib/cybersource/ext/active_merchant/active_merchant.rb
@@ -29,7 +29,7 @@ module ActiveMerchant
       def add_auth_service(xml, payment_method, options)
         if network_tokenization?(payment_method)
           add_network_tokenization(xml, payment_method, options)
-          add_payment_solution(xml, payment_method)
+          add_payment_solution(xml, payment_method, options)
         else
           xml.tag! 'ccAuthService', {'run' => 'true'} do
             # Let CyberSource figure it out otherwise (internet is the default unless tokens are used)
@@ -73,9 +73,10 @@ module ActiveMerchant
       # Changes:
       #  * http://apps.cybersource.com/library/documentation/dev_guides/Android_Pay_SO_API/html/wwhelp/wwhimpl/js/html/wwhelp.htm#href=ch_soAPI.html
       #  * add paymentSolution tag to support Android Pay
-      def add_payment_solution(xml, payment_method)
-        xml.tag!("paymentSolution", "006") if payment_method.source == :android_pay
+      def add_payment_solution(xml, payment_method, options)
+        xml.tag!("paymentSolution", "006") if options[:payment_method_type] == "androidpay"
       end
+
       # Changes:
       #  * Enable business rules for Apple Pay
       #  * Set paymentNetworkToken if needed (a bit of a hack to do it here, but it avoids having to override too much code)

--- a/lib/cybersource/ext/active_merchant/active_merchant.rb
+++ b/lib/cybersource/ext/active_merchant/active_merchant.rb
@@ -35,6 +35,8 @@ module ActiveMerchant
             xml.tag!("commerceIndicator", options[:commerce_indicator]) unless options[:commerce_indicator].blank?
           end
         end
+        # Add support for Android Pay
+        xml.tag!("paymentSolution", @options[:payment_solution]) unless options[:payment_solution].blank?
       end
 
       # Changes:

--- a/spec/cybersource/remote/integration_spec.rb
+++ b/spec/cybersource/remote/integration_spec.rb
@@ -184,6 +184,22 @@ describe Killbill::Cybersource::PaymentPlugin do
     check_response(payment_response, @amount, :PURCHASE, :PROCESSED, 'Successful transaction', '100')
   end
 
+  it 'should be able to bypass with Android Pay' do
+    properties = build_pm_properties(nil,
+                                     {
+                                         :cc_number => 4111111111111111,
+                                         :cc_type => 'visa',
+                                         :payment_cryptogram => 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+                                         :ignore_avs => true,
+                                         :ignore_cvv => true,
+                                         :source => android_pay
+                                     })
+    kb_payment = setup_kb_payment
+    payment_response = @plugin.authorize_payment(@pm.kb_account_id, kb_payment.id, kb_payment.transactions[0].id, @pm.kb_payment_method_id, @amount, @currency, properties, @call_context)
+    check_response(payment_response, @amount, :PURCHASE, :PROCESSED, 'Successful transaction', '100')
+
+  end
+
   it 'should be able to fix UNDEFINED payments' do
     payment_response = @plugin.purchase_payment(@pm.kb_account_id, @kb_payment.id, @kb_payment.transactions[0].id, @pm.kb_payment_method_id, @amount, @currency, @properties, @call_context)
     check_response(payment_response, @amount, :PURCHASE, :PROCESSED, 'Successful transaction', '100')

--- a/spec/cybersource/remote/integration_spec.rb
+++ b/spec/cybersource/remote/integration_spec.rb
@@ -191,8 +191,7 @@ describe Killbill::Cybersource::PaymentPlugin do
                                          :cc_type => 'visa',
                                          :payment_cryptogram => 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
                                          :ignore_avs => true,
-                                         :ignore_cvv => true,
-                                         :source => android_pay
+                                         :ignore_cvv => true
                                      })
     kb_payment = setup_kb_payment
     payment_response = @plugin.authorize_payment(@pm.kb_account_id, kb_payment.id, kb_payment.transactions[0].id, @pm.kb_payment_method_id, @amount, @currency, properties, @call_context)

--- a/spec/cybersource/remote/integration_spec.rb
+++ b/spec/cybersource/remote/integration_spec.rb
@@ -187,16 +187,15 @@ describe Killbill::Cybersource::PaymentPlugin do
   it 'should be able to bypass with Android Pay' do
     properties = build_pm_properties(nil,
                                      {
-                                         :cc_number => 4111111111111111,
+                                         :cc_number => 4895370012003478,
                                          :cc_type => 'visa',
-                                         :payment_cryptogram => 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+                                         :payment_cryptogram => 'AgAAAAAABk4DWZ4C28yUQAAAAAA=',
                                          :ignore_avs => true,
                                          :ignore_cvv => true
                                      })
     kb_payment = setup_kb_payment
     payment_response = @plugin.authorize_payment(@pm.kb_account_id, kb_payment.id, kb_payment.transactions[0].id, @pm.kb_payment_method_id, @amount, @currency, properties, @call_context)
-    check_response(payment_response, @amount, :PURCHASE, :PROCESSED, 'Successful transaction', '100')
-
+    check_response(payment_response, @amount, :AUTHORIZE, :PROCESSED, 'Successful transaction', '100')
   end
 
   it 'should be able to fix UNDEFINED payments' do


### PR DESCRIPTION
Base on CyberSource doc, android pay xml has <paymentSolution> tag : [CyberSource AndroidPay doc](http://apps.cybersource.com/library/documentation/dev_guides/Android_Pay_SO_API/html/wwhelp/wwhimpl/js/html/wwhelp.htm#href=ch_soAPI.html)
```xml
<paymentNetworkToken> 
    <transactionType>1</transactionType>
  </paymentNetworkToken>
  <paymentSolution>006</paymentSolution>
</requestMessage>
```
