### PR TITLE
change parm name to source

### DIFF
--- a/lib/cybersource/ext/active_merchant/active_merchant.rb
+++ b/lib/cybersource/ext/active_merchant/active_merchant.rb
@@ -74,7 +74,7 @@ module ActiveMerchant
       #  * http://apps.cybersource.com/library/documentation/dev_guides/Android_Pay_SO_API/html/wwhelp/wwhimpl/js/html/wwhelp.htm#href=ch_soAPI.html
       #  * add paymentSolution tag to support Android Pay
       def add_payment_solution(xml, payment_method, options)
-        xml.tag!("paymentSolution", "006") if options[:payment_method_type] == "androidpay"
+        xml.tag!("paymentSolution", "006") if options[:source] == "androidpay"
       end
 
       # Changes:


### PR DESCRIPTION
The last push was at the same time about merging.. changed parameter name to `:source`, so looks more compatible for least [ActiveMerchant#network_tokenization_credit_card](https://github.com/activemerchant/active_merchant/blob/master/lib/active_merchant/billing/network_tokenization_credit_card.rb)