### PR TITLE
handle 20bytes cryptogram for amex card

### DIFF
--- a/lib/cybersource/ext/active_merchant/active_merchant.rb
+++ b/lib/cybersource/ext/active_merchant/active_merchant.rb
@@ -64,7 +64,9 @@ module ActiveMerchant
             xml.tag! 'ccAuthService', {'run' => 'true'} do
               xml.tag!("cavv", Base64.encode64(cryptogram[0...20]))
               xml.tag!("commerceIndicator", options[:commerce_indicator] || "aesk")
-              xml.tag!("xid", Base64.encode64(cryptogram[20...40]))
+              if(cryptogram.size == 40)
+                xml.tag!("xid", Base64.encode64(cryptogram[20...40]))
+              end
             end
         end
       end

--- a/spec/cybersource/remote/integration_spec.rb
+++ b/spec/cybersource/remote/integration_spec.rb
@@ -182,6 +182,18 @@ describe Killbill::Cybersource::PaymentPlugin do
     kb_payment = setup_kb_payment
     payment_response = @plugin.purchase_payment(@pm.kb_account_id, kb_payment.id, kb_payment.transactions[0].id, @pm.kb_payment_method_id, @amount, @currency, properties, @call_context)
     check_response(payment_response, @amount, :PURCHASE, :PROCESSED, 'Successful transaction', '100')
+
+    properties = build_pm_properties(nil,
+                                     {
+                                         :cc_number => 378282246310005,
+                                         :cc_type => 'american_express',
+                                         :payment_cryptogram => 'AAAAAAAAAAAAAAAAAABBBBBBBBB=',
+                                         :ignore_avs => true,
+                                         :ignore_cvv => true
+                                     })
+    kb_payment = setup_kb_payment
+    payment_response = @plugin.purchase_payment(@pm.kb_account_id, kb_payment.id, kb_payment.transactions[0].id, @pm.kb_payment_method_id, @amount, @currency, properties, @call_context)
+    check_response(payment_response, @amount, :PURCHASE, :PROCESSED, 'Successful transaction', '100')
   end
 
   it 'should be able to pay with Android Pay' do
@@ -196,8 +208,50 @@ describe Killbill::Cybersource::PaymentPlugin do
     properties << build_property('source', 'androidpay')
 
     kb_payment = setup_kb_payment
-    payment_response = @plugin.authorize_payment(@pm.kb_account_id, kb_payment.id, kb_payment.transactions[0].id, @pm.kb_payment_method_id, @amount, @currency, properties, @call_context)
-    check_response(payment_response, @amount, :AUTHORIZE, :PROCESSED, 'Successful transaction', '100')
+    payment_response = @plugin.purchase_payment(@pm.kb_account_id, kb_payment.id, kb_payment.transactions[0].id, @pm.kb_payment_method_id, @amount, @currency, properties, @call_context)
+    check_response(payment_response, @amount, :PURCHASE, :PROCESSED, 'Successful transaction', '100')
+
+    properties = build_pm_properties(nil,
+                                     {
+                                         :cc_number => 5555555555554444,
+                                         :cc_type => 'master',
+                                         :payment_cryptogram => 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+                                         :ignore_avs => true,
+                                         :ignore_cvv => true
+                                     })
+    properties << build_property('source', 'androidpay')
+
+    kb_payment = setup_kb_payment
+    payment_response = @plugin.purchase_payment(@pm.kb_account_id, kb_payment.id, kb_payment.transactions[0].id, @pm.kb_payment_method_id, @amount, @currency, properties, @call_context)
+    check_response(payment_response, @amount, :PURCHASEE, :PROCESSED, 'Successful transaction', '100')
+
+    properties = build_pm_properties(nil,
+                                     {
+                                         :cc_number => 378282246310005,
+                                         :cc_type => 'american_express',
+                                         :payment_cryptogram => 'AAAAAAAAAAAAAAAAAAAAAAAAAAABBBBBBBBBBBBBBBBBBBBBBBBBBB==',
+                                         :ignore_avs => true,
+                                         :ignore_cvv => true
+                                     })
+    properties << build_property('source', 'androidpay')
+
+    kb_payment = setup_kb_payment
+    payment_response = @plugin.purchase_payment(@pm.kb_account_id, kb_payment.id, kb_payment.transactions[0].id, @pm.kb_payment_method_id, @amount, @currency, properties, @call_context)
+    check_response(payment_response, @amount, :PURCHASE, :PROCESSED, 'Successful transaction', '100')
+
+    properties = build_pm_properties(nil,
+                                     {
+                                         :cc_number => 378282246310005,
+                                         :cc_type => 'american_express',
+                                         :payment_cryptogram => 'AAAAAAAAAAAAAAAAAABBBBBBBBB=',
+                                         :ignore_avs => true,
+                                         :ignore_cvv => true
+                                     })
+    properties << build_property('source', 'androidpay')
+
+    kb_payment = setup_kb_payment
+    payment_response = @plugin.purchase_payment(@pm.kb_account_id, kb_payment.id, kb_payment.transactions[0].id, @pm.kb_payment_method_id, @amount, @currency, properties, @call_context)
+    check_response(payment_response, @amount, :PURCHASE, :PROCESSED, 'Successful transaction', '100')
   end
 
   it 'should be able to fix UNDEFINED payments' do

--- a/spec/cybersource/remote/integration_spec.rb
+++ b/spec/cybersource/remote/integration_spec.rb
@@ -223,7 +223,7 @@ describe Killbill::Cybersource::PaymentPlugin do
 
     kb_payment = setup_kb_payment
     payment_response = @plugin.purchase_payment(@pm.kb_account_id, kb_payment.id, kb_payment.transactions[0].id, @pm.kb_payment_method_id, @amount, @currency, properties, @call_context)
-    check_response(payment_response, @amount, :PURCHASEE, :PROCESSED, 'Successful transaction', '100')
+    check_response(payment_response, @amount, :PURCHASE, :PROCESSED, 'Successful transaction', '100')
 
     properties = build_pm_properties(nil,
                                      {


### PR DESCRIPTION
Both [cyberSource ApplePay](http://apps.cybersource.com/library/documentation/dev_guides/apple_payments/SO_API/html/wwhelp/wwhimpl/js/html/wwhelp.htm#href=ch_soAPI.html#1119413) & [cyberSource AndroidPay](http://apps.cybersource.com/library/documentation/dev_guides/Android_Pay_SO_API/html/wwhelp/wwhimpl/js/html/wwhelp.htm#href=ch_soAPI.html#1119413) are using the same way to handle amex card 

```
Step 3 Set the ccAuthService_cavv field to the 3D Secure cryptogram of the payment network token.
 Include the whole 20-byte cryptogram in the ccAuthService_cavv field. For a 40-byte cryptogram, split the cryptogram into two 20-byte binary values (block A and block B). Set the ccAuthService_cavv field to the block A value and set the ccAuthService_xid field to the block B value.
```
Add it to support 20-byte cryptogram


@pierre pls take a look :) 