### PR TITLE
Xqiu 20170818 add reconciliation

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,3 +171,4 @@ Plugin properties
 | force_validation             | If true, trigger a non-$0 auth to validate cards not supporting $0 auth |
 | force_validation_amount      | Amount to use when force_validation is set                              |
 | merchant_descriptor          | Merchant descriptor as `{"name":"Merchant Name","contact":"8888888888"}`|
+| reconciliation_id            | Optional reconciliation id. CYBS will generate one if not present.      |

--- a/lib/cybersource/api.rb
+++ b/lib/cybersource/api.rb
@@ -32,6 +32,7 @@ module Killbill #:nodoc:
 
         add_required_options(kb_account_id, properties, options, context)
         add_merchant_descriptor(:AUTHORIZE, properties, options)
+        add_reconciliation_id(properties, options)
 
         properties = merge_properties(properties, options)
         auth_response = super(kb_account_id, kb_payment_id, kb_payment_transaction_id, kb_payment_method_id, amount, currency, properties, context)
@@ -54,6 +55,7 @@ module Killbill #:nodoc:
 
         add_required_options(kb_account_id, properties, options, context)
         add_merchant_descriptor(:CAPTURE, properties, options)
+        add_reconciliation_id(properties, options)
 
         properties = merge_properties(properties, options)
         super(kb_account_id, kb_payment_id, kb_payment_transaction_id, kb_payment_method_id, amount, currency, properties, context)
@@ -84,6 +86,7 @@ module Killbill #:nodoc:
         options = {}
 
         add_required_options(kb_account_id, properties, options, context)
+        add_reconciliation_id(properties, options)
 
         properties = merge_properties(properties, options)
         super(kb_account_id, kb_payment_id, kb_payment_transaction_id, kb_payment_method_id, amount, currency, properties, context)
@@ -387,6 +390,11 @@ module Killbill #:nodoc:
           merchant_descriptor_hash[:card_type] = ::Killbill::Plugin::ActiveMerchant::Utils.normalized(properties_to_hash(properties), :cc_type)
         end
         options[:merchant_descriptor] = merchant_descriptor_hash
+      end
+
+      def add_reconciliation_id(properties, options)
+        reconciliation_id = find_value_from_properties(properties, 'reconciliation_id')
+        options[:reconciliation_id] = reconciliation_id if reconciliation_id.present?
       end
 
       def get_report_api(options, context)

--- a/lib/cybersource/ext/active_merchant/active_merchant.rb
+++ b/lib/cybersource/ext/active_merchant/active_merchant.rb
@@ -4,6 +4,7 @@ module ActiveMerchant
     KB_PLUGIN_VERSION = Gem.loaded_specs['killbill-cybersource'].version.version rescue nil
 
     class CyberSourceGateway
+      # The payload definitions: https://ics2wstest.ic3.com/commerce/1.x/transactionProcessor/CyberSourceTransaction_1.109.xsd
 
       def self.x_request_id
         # See KillbillMDCInsertingServletFilter
@@ -94,8 +95,8 @@ module ActiveMerchant
       def add_capture_service(xml, request_id, request_token, options = {})
         xml.tag! 'ccCaptureService', {'run' => 'true'} do
           xml.tag! 'authRequestID', request_id
+          add_reconciliation_id(xml, options) # the order is important
           xml.tag! 'authRequestToken', request_token
-          add_reconciliation_id(xml, options)
         end
       end
 
@@ -113,8 +114,8 @@ module ActiveMerchant
       def add_credit_service(xml, request_id = nil, request_token = nil, options = {})
         xml.tag! 'ccCreditService', {'run' => 'true'} do
           xml.tag! 'captureRequestID', request_id if request_id
-          xml.tag! 'captureRequestToken', request_token if request_token
           add_reconciliation_id(xml, options)
+          xml.tag! 'captureRequestToken', request_token if request_token
         end
       end
 

--- a/lib/cybersource/models/response.rb
+++ b/lib/cybersource/models/response.rb
@@ -37,7 +37,7 @@ module Killbill #:nodoc:
             :params_cv_code => extract(response, 'cvCode'),
             :params_authorized_date_time => extract(response, 'authorizedDateTime'),
             :params_processor_response => extract(response, 'processorResponse'),
-            :params_reconciliation_id => extract(response, 'reconciliationID') || extract(response, 'reconciliation_id'),
+            :params_reconciliation_id => extract(response, 'reconciliationID') || extract(response, 'reconciliation_id'), # when failure, use passed-in reconciliation id
             :params_subscription_id => extract(response, 'subscriptionID'),
         }
       end

--- a/lib/cybersource/models/response.rb
+++ b/lib/cybersource/models/response.rb
@@ -37,7 +37,7 @@ module Killbill #:nodoc:
             :params_cv_code => extract(response, 'cvCode'),
             :params_authorized_date_time => extract(response, 'authorizedDateTime'),
             :params_processor_response => extract(response, 'processorResponse'),
-            :params_reconciliation_id => extract(response, 'reconciliationID'),
+            :params_reconciliation_id => extract(response, 'reconciliationID') || extract(response, 'reconciliation_id'),
             :params_subscription_id => extract(response, 'subscriptionID'),
         }
       end


### PR DESCRIPTION
This PR is for https://github.com/killbill/killbill-cybersource-plugin/issues/19
add optional reconciliation_id, if present, will pass to Cybersource and record it even if the transaction failed.
@pierre please review, thanks!