### PR TITLE
Allow alternative (16-character) subscription (profile) IDs

### DIFF
--- a/lib/cybersource/ext/active_merchant/active_merchant.rb
+++ b/lib/cybersource/ext/active_merchant/active_merchant.rb
@@ -192,7 +192,7 @@ module ActiveMerchant
         response[:reconciliation_id] = options[:reconciliation_id] if options[:reconciliation_id].present?
 
         success = response[:decision] == 'ACCEPT'
-        authorization = success ? [options[:order_id], response[:requestID], response[:requestToken]].compact.join(';') : nil
+        authorization = success ? [options[:order_id], response['subscriptionID'] || response[:requestID], response[:requestToken]].compact.join(';') : nil
 
         message = nil
         if response[:reasonCode].blank? && (response[:faultcode] == 'wsse:FailedCheck' || response[:faultcode] == 'wsse:InvalidSecurity' || response[:faultcode] == 'soap:Client' || response[:faultcode] == 'c:ServerError')


### PR DESCRIPTION
Resolves killbill/killbill-cybersource-plugin#14 per [discussion](https://groups.google.com/forum/#!topic/killbilling-users/JCYyrxDM71w) with @pierre.

Integration tests (`bundle exec rake test:remote:spec`) pass against a merchant that uses default 22-character subscription IDs and against a merchant that uses 16-character subscription IDs.